### PR TITLE
Feature/all divisions

### DIFF
--- a/commands/banzukecommand.go
+++ b/commands/banzukecommand.go
@@ -1,8 +1,5 @@
 package commands
 
-//TODO: way too much sumo logic is stored in this command.
-// this should be refactored to seperate that logic out into
-// its own package.
 import (
 	"flag"
 	"fmt"
@@ -19,7 +16,7 @@ type (
 	BanzukeCommand struct {
 		BanzukeFlags *flag.FlagSet
 		bashoID      int
-		divisions    []string
+		divisions    DivisionFlag
 		sysConfig    sumoutils.Config
 	}
 )
@@ -31,6 +28,7 @@ func NewBanzukeCommand(config sumoutils.Config) *BanzukeCommand {
 		sysConfig:    config,
 	}
 	cmd.BanzukeFlags.IntVar(&cmd.bashoID, "basho-id", -1, "The basho to target <YYYYMM>")
+	cmd.BanzukeFlags.Var(&cmd.divisions, "division", "A Division to target")
 	return cmd
 }
 
@@ -42,6 +40,11 @@ func (cmd *BanzukeCommand) CommandName() string {
 // Parse the args received from the OS
 func (cmd *BanzukeCommand) Parse(osArgs []string) error {
 	cmd.BanzukeFlags.Parse(osArgs)
+	if len(cmd.divisions) < 1 {
+		// if no divison arguments are provided, default to getting
+		// Makuuchi and Juryo
+		cmd.divisions = append(cmd.divisions, "M", "J")
+	}
 	return nil
 }
 
@@ -54,6 +57,10 @@ func (cmd *BanzukeCommand) Run() error {
 
 	c := colly.NewCollector()
 	RikishiList := []sumomodel.Rikishi{}
+	RequestedDivisions, err := sumomodel.GetDivisionList(cmd.divisions)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 
 	c.OnRequest(func(r *colly.Request) {
 		fmt.Println("visiting", r.URL)
@@ -68,9 +75,9 @@ func (cmd *BanzukeCommand) Run() error {
 
 	c.OnHTML("table.banzuke", func(e *colly.HTMLElement) {
 
-		tableCaption := e.ChildText("caption")
-		// only target Makuuchi and juryo divisions.
-		if strings.Contains(tableCaption, "Makuuchi") || strings.Contains(tableCaption, "Juryo") {
+		tableDivision := strings.Split(e.ChildText("caption"), " ")[0]
+
+		if IsRequestedDivision(RequestedDivisions, tableDivision) {
 
 			// each tr should represent 1 rikishi
 			e.ForEach("tr", func(i int, tr *colly.HTMLElement) {

--- a/commands/banzukecommand.go
+++ b/commands/banzukecommand.go
@@ -18,10 +18,9 @@ type (
 	//BanzukeCommand struct containing the Flags for the command and variables that the are used when parsing.
 	BanzukeCommand struct {
 		BanzukeFlags *flag.FlagSet
-		// ID of target basho. in YYYYMM format
-		bashoID int
-
-		sysConfig sumoutils.Config
+		bashoID      int
+		divisions    []string
+		sysConfig    sumoutils.Config
 	}
 )
 
@@ -111,7 +110,6 @@ func (cmd *BanzukeCommand) Run() error {
 	// save data post scrape.
 	c.OnScraped(func(r *colly.Response) {
 		fileName := sumoutils.CreateFileName(cmd.CommandName())
-		fmt.Println(cmd.sysConfig.SavePath)
 		err := sumoutils.JSONFileWriter(cmd.sysConfig.SavePath+fileName, RikishiList)
 		if err != nil {
 			fmt.Println(err.Error())

--- a/commands/common.go
+++ b/commands/common.go
@@ -1,6 +1,10 @@
 package commands
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/jph5396/sumoscrape/sumomodel"
+)
 
 // common functions and types that are used by multiple commands.
 
@@ -21,7 +25,30 @@ func (d *DivisionFlag) String() string {
 
 // Set Division flag implementation of the Set(string)
 // function required by the flags.Value interface
-func (d *DivisionFlag) Set(str string) error {
-	*d = append(*d, str)
+func (d *DivisionFlag) Set(s string) error {
+	*d = append(*d, s)
 	return nil
+}
+
+// IsRequestedDivision is used to check if a banzuke/ bout was requested
+// by the user. it will return true if the str is present in the division
+// list.
+func IsRequestedDivision(d []sumomodel.Division, str string) bool {
+	for _, item := range d {
+		if str == item.DivLongName {
+			return true
+		}
+	}
+	return false
+}
+
+// IsRequestedDivisionByID is used to check if a banzuke/ bout was requested
+// by the user based on the ID provided.
+func IsRequestedDivisionByID(d []sumomodel.Division, id int) bool {
+	for _, item := range d {
+		if id == item.ID {
+			return true
+		}
+	}
+	return false
 }

--- a/commands/common.go
+++ b/commands/common.go
@@ -1,0 +1,27 @@
+package commands
+
+import "strings"
+
+// common functions and types that are used by multiple commands.
+
+type (
+	//DivisionFlag an array of strings that are used to decide which divisions to target when scrapping.
+	// it implements the value interface from the flag package.
+	DivisionFlag []string
+)
+
+func (d *DivisionFlag) String() string {
+	var builder strings.Builder
+
+	for _, item := range *d {
+		builder.WriteString(item)
+	}
+	return builder.String()
+}
+
+// Set Division flag implementation of the Set(string)
+// function required by the flags.Value interface
+func (d *DivisionFlag) Set(str string) error {
+	*d = append(*d, str)
+	return nil
+}

--- a/sumomodel/division.go
+++ b/sumomodel/division.go
@@ -76,9 +76,9 @@ var longForm = map[string]Division{
 	jonokuchi.DivLongName: jonokuchi,
 }
 
-// GetDivisionInfo returns the requested division if it exists, or nil if it doesnt.
+// GetDivision returns the requested division if it exists, or nil if it doesnt.
 // Divisions can be requested by either their short or long forms
-func GetDivisionInfo(str string) (Division, error) {
+func GetDivision(str string) (Division, error) {
 	// check if str is less than 3 characters. If it is,
 	// get Division via the short form.
 	if len(str) < 3 {
@@ -93,4 +93,19 @@ func GetDivisionInfo(str string) (Division, error) {
 	}
 
 	return Division{}, errors.New("division does not exist")
+}
+
+//GetDivisionList takes in a list of requested divisions and
+func GetDivisionList(list []string) ([]Division, error) {
+
+	var divList []Division
+	for _, item := range list {
+		division, err := GetDivision(item)
+		if err != nil {
+			return nil, err
+		}
+		divList = append(divList, division)
+	}
+
+	return divList, nil
 }

--- a/sumomodel/division.go
+++ b/sumomodel/division.go
@@ -1,0 +1,96 @@
+package sumomodel
+
+import "errors"
+
+type (
+	//Division Represents the a division of sumo wrestlers.
+	// Each division contains an ID, the full name, a short version
+	// of the name, and a Regex string used to confirm if a rank is
+	// in said division.
+	Division struct {
+		ID          int
+		DivLongName string
+		ShortName   string
+		RankRegex   string
+	}
+)
+
+// Divisions are not exported and can only be accessed via functions.
+var makuuchi = Division{
+	ID:          1,
+	DivLongName: "Makuuchi",
+	ShortName:   "M",
+	RankRegex:   "[YOSKM]\\d{1,3}[ew](HD|YO)?",
+}
+
+var juryo = Division{
+	ID:          2,
+	DivLongName: "Juryo",
+	ShortName:   "J",
+	RankRegex:   "J\\d{1,3}[ew]",
+}
+
+var makushita = Division{
+	ID:          3,
+	DivLongName: "Makushita",
+	ShortName:   "Ms",
+	RankRegex:   "Ms\\d{1,3}([ew]|TD)?",
+}
+
+var sandanme = Division{
+	ID:          4,
+	DivLongName: "Sandanme",
+	ShortName:   "Sd",
+	RankRegex:   "Sd\\d{1,4}([ew]|TD)?",
+}
+
+var jonidan = Division{
+	ID:          5,
+	DivLongName: "Jonidan",
+	ShortName:   "Jd",
+	RankRegex:   "Jd\\d{1,4}[ew]",
+}
+
+var jonokuchi = Division{
+	ID:          6,
+	DivLongName: "Jonokuchi",
+	ShortName:   "Jk",
+	RankRegex:   "Jk\\d{1,3}[ew]",
+}
+
+// create maps based on both long and short forms of the divisions.
+var shortForm = map[string]Division{
+	makuuchi.ShortName:  makuuchi,
+	juryo.ShortName:     juryo,
+	makushita.ShortName: makushita,
+	sandanme.ShortName:  sandanme,
+	jonidan.ShortName:   jonidan,
+	jonokuchi.ShortName: jonokuchi,
+}
+var longForm = map[string]Division{
+	makuuchi.DivLongName:  makuuchi,
+	juryo.DivLongName:     juryo,
+	makushita.DivLongName: makushita,
+	sandanme.DivLongName:  sandanme,
+	jonidan.DivLongName:   jonidan,
+	jonokuchi.DivLongName: jonokuchi,
+}
+
+// GetDivisionInfo returns the requested division if it exists, or nil if it doesnt.
+// Divisions can be requested by either their short or long forms
+func GetDivisionInfo(str string) (Division, error) {
+	// check if str is less than 3 characters. If it is,
+	// get Division via the short form.
+	if len(str) < 3 {
+		if val, ok := shortForm[str]; ok {
+			return val, nil
+		}
+		return Division{}, errors.New("division does not exist")
+	}
+
+	if val, ok := longForm[str]; ok {
+		return val, nil
+	}
+
+	return Division{}, errors.New("division does not exist")
+}


### PR DESCRIPTION
a user can now request a specific division by using the `--division` flag. If the flag is not provided, sumoscrape will default to the old functionality of scraping for makuuchi and Juryo divisions. 